### PR TITLE
Make https optional

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -10,7 +10,6 @@ test('test runs', () => {
   process.env['INPUT_ARGOCD-VERSION'] = 'v1.6.1';
   process.env['INPUT_ARGOCD-SERVER-URL'] = 'argocd.qzlt.io';
   process.env['INPUT_ARGOCD-TOKEN'] = 'foo';
-  process.env['INPUT_TOKEN'] = 'foo';
   const ip = path.join(__dirname, '..', 'lib', 'main.js');
   const options: cp.ExecSyncOptions = {
     env: process.env

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -10,6 +10,7 @@ test('test runs', () => {
   process.env['INPUT_ARGOCD-VERSION'] = 'v1.6.1';
   process.env['INPUT_ARGOCD-SERVER-URL'] = 'argocd.qzlt.io';
   process.env['INPUT_ARGOCD-TOKEN'] = 'foo';
+  process.env['INPUT_TOKEN'] = 'foo';
   const ip = path.join(__dirname, '..', 'lib', 'main.js');
   const options: cp.ExecSyncOptions = {
     env: process.env

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,8 @@ author: 'Quizlet'
 inputs:
   argocd-server-url: 
     description: ArgoCD server url (without the protocol)
-    required: true
+    default: argo-cd-argocd-server.argo-cd
+    required: false
   argocd-token: 
     description: ArgoCD token for a local or project-scoped user https://argoproj.github.io/argo-cd/operator-manual/user-management/#local-usersaccounts-v15
     required: true
@@ -18,6 +19,14 @@ inputs:
   argocd-extra-cli-args: 
     description: Extra arguments to pass to the argocd CLI
     default: --grpc-web
+    required: false
+  plaintext: 
+    description: Whether to use HTTPS
+    default: 'false'
+    required: false
+  environment: 
+    description: Name of env to use in the diff title posted to the PR
+    default: legacy
     required: false
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1697,7 +1697,12 @@ core.info(githubToken);
 const ARGOCD_SERVER_URL = core.getInput('argocd-server-url');
 const ARGOCD_TOKEN = core.getInput('argocd-token');
 const VERSION = core.getInput('argocd-version');
-const EXTRA_CLI_ARGS = core.getInput('argocd-extra-cli-args');
+const ENV = core.getInput('environment');
+const PLAINTEXT = core.getInput('plaintext').toLowerCase() === "true";
+let EXTRA_CLI_ARGS = core.getInput('argocd-extra-cli-args');
+if (PLAINTEXT) {
+    EXTRA_CLI_ARGS += ' --plaintext';
+}
 const octokit = github.getOctokit(githubToken);
 function execCommand(command, options = {}) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1739,7 +1744,11 @@ function setupArgoCDCommand() {
 }
 function getApps() {
     return __awaiter(this, void 0, void 0, function* () {
-        const url = `https://${ARGOCD_SERVER_URL}/api/v1/applications?fields=items.metadata.name,items.spec.source.path,items.spec.source.repoURL,items.spec.source.targetRevision,items.spec.source.helm,items.spec.source.kustomize,items.status.sync.status`;
+        let protocol = 'https';
+        if (PLAINTEXT) {
+            protocol = 'http';
+        }
+        const url = `${protocol}://${ARGOCD_SERVER_URL}/api/v1/applications`;
         core.info(`Fetching apps from: ${url}`);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let responseJson;
@@ -1754,7 +1763,8 @@ function getApps() {
             core.error(e);
         }
         return responseJson.items.filter(app => {
-            return (app.spec.source.repoURL.includes(`${github.context.repo.owner}/${github.context.repo.repo}`) && (app.spec.source.targetRevision === 'master' || app.spec.source.targetRevision === 'main'));
+            const targetPrimary = app.spec.source.targetRevision === 'master' || app.spec.source.targetRevision === 'main';
+            return (app.spec.source.repoURL.includes(`${github.context.repo.owner}/${github.context.repo.repo}`) && targetPrimary);
         });
     });
 }
@@ -1797,7 +1807,7 @@ ${diff}
 ---
 `);
         const output = scrubSecrets(`
-## ArgoCD Diff for commit [\`${shortCommitSha}\`](${commitLink})
+## ArgoCD Diff on ${ENV} for commit [\`${shortCommitSha}\`](${commitLink})
 _Updated at ${new Date().toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })} PT_
   ${diffOutput.join('\n')}
 
@@ -1807,23 +1817,8 @@ _Updated at ${new Date().toLocaleString('en-US', { timeZone: 'America/Los_Angele
 | ⚠️      | The app is out-of-sync in ArgoCD, and the diffs you see include those changes plus any from this PR. |
 | 🛑     | There was an error generating the ArgoCD diffs due to changes in this PR. |
 `);
-        const commentsResponse = yield octokit.rest.issues.listComments({
-            issue_number: github.context.issue.number,
-            owner,
-            repo
-        });
-        const existingComment = commentsResponse.data.find(d => d.body.includes('ArgoCD Diff for'));
-        // Existing comments should be updated even if there are no changes this round in order to indicate that
-        if (existingComment) {
-            octokit.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existingComment.id,
-                body: output
-            });
-            // Only post a new comment when there are changes
-        }
-        else if (diffs.length) {
+        // Only post a new comment when there are changes
+        if (diffs.length) {
             octokit.rest.issues.createComment({
                 issue_number: github.context.issue.number,
                 owner,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3182,6 +3182,19 @@
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
+    "node_modules/flow-bin": {
+      "version": "0.223.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.223.0.tgz",
+      "integrity": "sha512-E+GmTcBTPIRfnX/Dk19zJewX9grxoVQU+RG3Ypd/Os0OkUSOF7K3Sxo2I+8Oz1EpnPMGhnbM4WRAUuY0JaHRsw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "flow": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -10916,6 +10929,13 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "flow-bin": {
+      "version": "0.223.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.223.0.tgz",
+      "integrity": "sha512-E+GmTcBTPIRfnX/Dk19zJewX9grxoVQU+RG3Ypd/Os0OkUSOF7K3Sxo2I+8Oz1EpnPMGhnbM4WRAUuY0JaHRsw==",
+      "dev": true,
+      "peer": true
     },
     "for-in": {
       "version": "1.0.2",


### PR DESCRIPTION
### Motivation
- Moving to decentralized ArgoCD per cluster paradigm, we can now use and internal address to get ArgoCD diffs
- Action needs to take into account multiple diff comments for different argocd instances per commit
  - The current behavior to overwrite of existing comments causes race conditions and ultimately only a single diff gets posted
  - We also need to each diff to identity which cluster it's from
 
 ### Changes
  - Adds a new `plaintext` input which bypasses the need for a verifiable cert (which is also not setup in the new cluster)
  - Adds a new `environment` input for customizing the diff comment title
  - Posts new diff comments on each commit
    - Open to suggestions on this, but thought the need to look at old comments to get the latest diff is confusing
    - Would rather delete outdate ones and alway post a new comment
        
 ### Future work
- We need to migrate away from using local diffs `--local` to server-side diffs since this option is being deprecated
- There are also additional performance optimizations that we should probably make before doing that though (since it causes lots of manifests generations on each PR commit on the remote argocd instances (e.x. repo-server).

### Tagging
- I think we should tag master before merging just so legacy runs can easily revert
- We should also tag post merge with an upgrade so we can start locking to a tag
