### PR TITLE
Use server side diff

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1864,7 +1864,7 @@ function run() {
         core.info(`Found apps: ${apps.map(a => a.metadata.name).join(', ')}`);
         const diffs = [];
         yield asyncForEach(apps, (app) => __awaiter(this, void 0, void 0, function* () {
-            const command = `app diff ${app.metadata.name} --local=${app.spec.source.path}`;
+            const command = `app diff ${app.metadata.name} --local=./ --server-side-generate`;
             try {
                 core.info(`Running: argocd ${command}`);
                 // ArgoCD app diff will exit 1 if there is a diff, so always catch,

--- a/dist/index.js
+++ b/dist/index.js
@@ -1864,7 +1864,7 @@ function run() {
         core.info(`Found apps: ${apps.map(a => a.metadata.name).join(', ')}`);
         const diffs = [];
         yield asyncForEach(apps, (app) => __awaiter(this, void 0, void 0, function* () {
-            const command = `app diff ${app.metadata.name} --local=${process.cwd()} --server-side-generate`;
+            const command = `app diff ${app.metadata.name} --server-side-generate`;
             try {
                 core.info(`Running: argocd ${command}`);
                 // ArgoCD app diff will exit 1 if there is a diff, so always catch,

--- a/dist/index.js
+++ b/dist/index.js
@@ -1864,7 +1864,7 @@ function run() {
         core.info(`Found apps: ${apps.map(a => a.metadata.name).join(', ')}`);
         const diffs = [];
         yield asyncForEach(apps, (app) => __awaiter(this, void 0, void 0, function* () {
-            const command = `app diff ${app.metadata.name} --local=./ --server-side-generate`;
+            const command = `app diff ${app.metadata.name} --local=/ --server-side-generate`;
             try {
                 core.info(`Running: argocd ${command}`);
                 // ArgoCD app diff will exit 1 if there is a diff, so always catch,

--- a/dist/index.js
+++ b/dist/index.js
@@ -1864,7 +1864,7 @@ function run() {
         core.info(`Found apps: ${apps.map(a => a.metadata.name).join(', ')}`);
         const diffs = [];
         yield asyncForEach(apps, (app) => __awaiter(this, void 0, void 0, function* () {
-            const command = `app diff ${app.metadata.name} --local=/ --server-side-generate`;
+            const command = `app diff ${app.metadata.name} --local=${process.cwd()} --server-side-generate`;
             try {
                 core.info(`Running: argocd ${command}`);
                 // ArgoCD app diff will exit 1 if there is a diff, so always catch,

--- a/src/main.ts
+++ b/src/main.ts
@@ -232,7 +232,7 @@ async function run(): Promise<void> {
   const diffs: Diff[] = [];
 
   await asyncForEach(apps, async app => {
-    const command = `app diff ${app.metadata.name} --local=/ --server-side-generate`;
+    const command = `app diff ${app.metadata.name} --local=${process.cwd()} --server-side-generate`;
     try {
       core.info(`Running: argocd ${command}`);
       // ArgoCD app diff will exit 1 if there is a diff, so always catch,

--- a/src/main.ts
+++ b/src/main.ts
@@ -232,7 +232,7 @@ async function run(): Promise<void> {
   const diffs: Diff[] = [];
 
   await asyncForEach(apps, async app => {
-    const command = `app diff ${app.metadata.name} --local=${app.spec.source.path}`;
+    const command = `app diff ${app.metadata.name} --local=./ --server-side-generate`;
     try {
       core.info(`Running: argocd ${command}`);
       // ArgoCD app diff will exit 1 if there is a diff, so always catch,

--- a/src/main.ts
+++ b/src/main.ts
@@ -232,7 +232,7 @@ async function run(): Promise<void> {
   const diffs: Diff[] = [];
 
   await asyncForEach(apps, async app => {
-    const command = `app diff ${app.metadata.name} --local=./ --server-side-generate`;
+    const command = `app diff ${app.metadata.name} --local=/ --server-side-generate`;
     try {
       core.info(`Running: argocd ${command}`);
       // ArgoCD app diff will exit 1 if there is a diff, so always catch,

--- a/src/main.ts
+++ b/src/main.ts
@@ -232,7 +232,7 @@ async function run(): Promise<void> {
   const diffs: Diff[] = [];
 
   await asyncForEach(apps, async app => {
-    const command = `app diff ${app.metadata.name} --local=${process.cwd()} --server-side-generate`;
+    const command = `app diff ${app.metadata.name} --server-side-generate`;
     try {
       core.info(`Running: argocd ${command}`);
       // ArgoCD app diff will exit 1 if there is a diff, so always catch,


### PR DESCRIPTION
- Local diffing is [deprecated](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.4-2.5/#deprecated-client-side-manifest-diffs) in-favor or server-side diffs
- This also has the benefits of cleaning up the diff [output](https://github.com/quizlet/quizlet-infrastructure/pull/7025#issuecomment-2239982670) to actually only show apps that have areal diffs