### PR TITLE
Remove expand drop down

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1884,15 +1884,11 @@ function partOfApp(changedFiles, app) {
     });
 }
 function getFirstTwoDirectories(filePath) {
-    // Normalize the path to handle any inconsistencies
     const normalizedPath = path.normalize(filePath);
-    // Split the path into parts based on the OS-specific separator
     const parts = normalizedPath.split(path.sep).filter(Boolean); // filter(Boolean) removes empty strings
-    // Check if the path has at least two segments
     if (parts.length < 2) {
         return parts.join(path.sep); // Return the entire path if less than two directories
     }
-    // Join the first two segments
     return parts.slice(0, 2).join(path.sep);
 }
 function asyncForEach(array, callback) {
@@ -1944,13 +1940,13 @@ function filterDiff(diffText) {
     // Split the diff text into sections based on the headers
     const sections = diffText.split(/(?=^===== )/m);
     const filteredSection = sections.map(section => {
-        var removedLabels = section.replace(/<\s+argocd\.argoproj\.io\/instance:.*\n---\n>\s+argocd\.argoproj\.io\/instance:.*\n?/g, '').trim();
-        var removedLabels = removedLabels.replace(/<\s+app.kubernetes.io\/part-of:.*\n?/g, '').trim();
+        var removedLabels = section.replace(/(\d+(,\d+)?c\d+(,\d+)?\n)?<\s+argocd\.argoproj\.io\/instance:.*\n---\n>\s+argocd\.argoproj\.io\/instance:.*\n?/g, '').trim();
+        removedLabels = removedLabels.replace(/(\d+(,\d+)?c\d+(,\d+)?\n)?<\s+app.kubernetes.io\/part-of:.*\n?/g, '').trim();
         return removedLabels;
     }).filter(section => section.trim() !== '');
     const removeEmptyHeaders = filteredSection.filter(entry => {
         // Remove empty strings and sections that are just headers with line numbers
-        return !entry.match(/^===== .*\/.* ======\n\d+(,\d+)?c\d+(,\d+)?$/);
+        return !entry.match(/^===== .*\/.* ======$/);
     });
     // Join the filtered sections back together
     return removeEmptyHeaders.join('\n').trim();

--- a/dist/index.js
+++ b/dist/index.js
@@ -1813,13 +1813,11 @@ ${JSON.stringify(error.err)}
 
 ${diff
             ? `
-<details>
 
 \`\`\`diff
 ${diff}
 \`\`\`
 
-</details>
 `
             : ''}
 ---

--- a/src/main.ts
+++ b/src/main.ts
@@ -173,13 +173,11 @@ ${JSON.stringify(error.err)}
 ${
       diff
         ? `
-<details>
 
 \`\`\`diff
 ${diff}
 \`\`\`
 
-</details>
 `
         : ''
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -312,14 +312,14 @@ function filterDiff(diffText: string) {
   const sections = diffText.split(/(?=^===== )/m);
 
   const filteredSection = sections.map(section => {
-    var removedLabels = section.replace(/<\s+argocd\.argoproj\.io\/instance:.*\n---\n>\s+argocd\.argoproj\.io\/instance:.*\n?/g, '').trim();
-    var removedLabels = removedLabels.replace(/<\s+app.kubernetes.io\/part-of:.*\n?/g, '').trim();
+    var removedLabels = section.replace(/(\d+(,\d+)?c\d+(,\d+)?\n)?<\s+argocd\.argoproj\.io\/instance:.*\n---\n>\s+argocd\.argoproj\.io\/instance:.*\n?/g, '').trim();
+    removedLabels = removedLabels.replace(/(\d+(,\d+)?c\d+(,\d+)?\n)?<\s+app.kubernetes.io\/part-of:.*\n?/g, '').trim();
     return removedLabels;
   }).filter(section => section.trim() !== '');
 
   const removeEmptyHeaders = filteredSection.filter(entry => {
     // Remove empty strings and sections that are just headers with line numbers
-    return !entry.match(/^===== .*\/.* ======\n\d+(,\d+)?c\d+(,\d+)?$/);
+    return !entry.match(/^===== .*\/.* ======$/);
   });
 
   // Join the filtered sections back together


### PR DESCRIPTION
With a more concise diff output, there's no need to hide the diff behind an expand button 