### PR TITLE
fix: add --local-repo-root option (with thanks to #53)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -282,7 +282,7 @@ _Updated at ${new Date().toLocaleString('en-US', { timeZone: 'America/Los_Angele
   const diffs: Diff[] = [];
 
   await asyncForEach(apps, async app => {
-    const command = `app diff ${app.metadata.name} --local=${app.spec.source.path}`;
+    const command = `app diff ${app.metadata.name} --local-repo-root=${process.cwd()} --local=${app.spec.source.path}`;
     try {
       core.info(`Running: argocd ${command}`);
       // ArgoCD app diff will exit 1 if there is a diff, so always catch,


### PR DESCRIPTION
This was requested by #53, and fixes an issue that seemed to start with argocd cli v2.13.1 for us, but only shows up with a few apps for some reason. I do not know precisely what changed in argocd to cause the issue.